### PR TITLE
:fire: (client/sidebar): Remove team section

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -37,7 +37,6 @@ export default function Sidebar() {
       badge: 5,
     },
     { name: 'Calendar', href: '/dashboard/calendar', icon: <Calendar className="h-5 w-5" /> },
-    { name: 'Team', href: '/dashboard/team', icon: <Users className="h-5 w-5" /> },
   ];
 
   const bottomNavItems: NavItem[] = [


### PR DESCRIPTION
This pull request includes a small change to the `Sidebar` component. The change removes the "Team" navigation item from the `topNavItems` array in the `src/components/layout/Sidebar.tsx` file.