### PR TITLE
🔧 Change docker-compose with "NODE_ENV"

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,6 +57,7 @@ services:
     volumes:
       - .:/app
     environment:
+      - NODE_ENV=development
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/nextjs_dev
     depends_on:
       prisma-migrate:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,7 @@ services:
       dockerfile: Dockerfile
       target: development
     environment:
+      - NODE_ENV=production
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/nextjs_prod
       - ADMIN_EMAIL=${ADMIN_EMAIL}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,16 +5,29 @@ const prisma = new PrismaClient();
 
 async function main() {
   // Clean up existing data
-  await prisma.userTask.deleteMany();
-  await prisma.task.deleteMany();
-  await prisma.project.deleteMany();
-  await prisma.user.deleteMany();
+  if (process.env.NODE_ENV !== 'production') {
+    await prisma.userTask.deleteMany();
+    await prisma.task.deleteMany();
+    await prisma.project.deleteMany();
+    await prisma.user.deleteMany();
+  }
 
-  console.log('Seeding the database...');
+  console.log('🌱 Seeding the database...');
 
   // Create users
   const adminPassword = await bcrypt.hash(process.env.ADMIN_PASSWORD as string, 10);
   const userPassword = await bcrypt.hash('user123', 10);
+
+  const adminExists = await prisma.user.findUnique({
+    where: {
+      email: process.env.ADMIN_EMAIL as string,
+    },
+  });
+
+  if (adminExists) {
+    console.log('🔑 Admin user already exists. Skipping user creation.');
+    return;
+  }
 
   const admin = await prisma.user.create({
     data: {
@@ -24,6 +37,12 @@ async function main() {
       role: Role.ADMIN,
     },
   });
+
+  if (process.env.NODE_ENV === 'production') {
+    console.log('🔑 Production environment detected. Skipping user creation.');
+    console.log('👑 Admin user created:', admin.email);
+    return;
+  }
 
   const user1 = await prisma.user.create({
     data: {
@@ -41,7 +60,7 @@ async function main() {
     },
   });
 
-  console.log('Created users');
+  console.log('👤 Created users');
 
   // Create a project
   const projectOne = await prisma.project.create({
@@ -64,7 +83,7 @@ async function main() {
     },
   });
 
-  console.log('Created projects');
+  console.log('🏗️ Created projects');
 
   // Create tasks for project one
   const taskOne = await prisma.task.create({
@@ -101,7 +120,7 @@ async function main() {
     },
   });
 
-  console.log('Created tasks');
+  console.log('🔨 Created tasks');
 
   // Assign tasks to users
   await prisma.userTask.create({
@@ -125,9 +144,9 @@ async function main() {
     },
   });
 
-  console.log('Assigned tasks to users');
+  console.log('🔄 Assigned tasks to users');
 
-  console.log('Database seeded successfully');
+  console.log('🌳 Database seeded successfully');
 }
 
 main()


### PR DESCRIPTION
This pull request introduces several changes to improve environment-specific configurations and enhance the database seeding process. Key updates include setting `NODE_ENV` in Docker Compose files, adding conditional logic to the seed script to handle production environments, and improving log message clarity with emojis and more descriptive text.

### Environment Configuration Updates:
* Added `NODE_ENV=development` to `docker-compose.dev.yml` to explicitly set the environment for development.
* Added `NODE_ENV=production` to `docker-compose.prod.yml` to explicitly set the environment for production.

### Database Seeding Enhancements:
* Updated `prisma/seed.ts` to skip data cleanup and user creation in production environments by checking `NODE_ENV`. [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR8-R31) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR41-R46)
* Added a check to prevent duplicate admin user creation if the admin already exists in the database.
* Improved log messages in `prisma/seed.ts` with emojis and clearer descriptions for better readability during the seeding process. [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR8-R31) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL44-R63) [[3]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL67-R86) [[4]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL104-R123) [[5]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL128-R149)