### PR TITLE
✨ Add patchnote base

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,20 @@
 name: Deploy to Production
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [closed]
+  workflow_run:
+    workflows: ["Publish Patchnote"]
+    types:
+      - completed
     branches:
       - main
 
 jobs:
   deploy:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
-    name: Deploy to VPS
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-patchnotes.yml
+++ b/.github/workflows/publish-patchnotes.yml
@@ -1,0 +1,114 @@
+# .github/workflows/publish-patchnote.yml
+name: Publish Patchnote
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  publish-patchnote:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      patchnote_updated: ${{ steps.check_file.outputs.exists }}
+      version: ${{ steps.version.outputs.new_version }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          
+      - name: Check if patchnote-draft.json exists
+        id: check_file
+        run: |
+          if [ -f "patchnote-draft.json" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "No patchnote-draft.json found. Skipping patchnote publication."
+          fi
+          
+      - name: Generate version number
+        if: steps.check_file.outputs.exists == 'true'
+        id: version
+        run: |
+          # Get latest tag or default to v0.0.0 if none exists
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_VERSION=${LATEST_TAG#v}
+          
+          # Increment the minor version number
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
+          NEW_VERSION="$MAJOR.$((MINOR + 1)).$PATCH"
+          
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Generated new version: $NEW_VERSION"
+          
+      - name: Update patchnote version and title
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          # Use jq to update the version and title
+          jq --arg version "$NEW_VERSION" \
+             --arg title "Mise à jour $NEW_VERSION" \
+             '.version = $version | .title = $title' \
+             patchnote-draft.json > patchnote-final.json
+          
+          echo "Updated patchnote with version $NEW_VERSION"
+      
+      - name: Create patchnotes directory
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          mkdir -p docs/patchnotes
+      
+      - name: Save final patchnote to patchnotes directory
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          cp patchnote-final.json "docs/patchnotes/v$NEW_VERSION.json"
+          echo "Saved patchnote as docs/patchnotes/v$NEW_VERSION.json"
+      
+      - name: Create git tag
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "GitHub Actions"
+          
+          git tag "v$NEW_VERSION"
+          git push origin "v$NEW_VERSION"
+          
+          echo "Created and pushed tag v$NEW_VERSION"
+      
+      - name: Commit patchnote to repository
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "GitHub Actions"
+          
+          git add docs/patchnotes/
+          git commit -m "docs(patchnotes): Add patchnote for v$NEW_VERSION"
+          git push origin main
+          
+          echo "Committed and pushed patchnote to repository"
+              
+      - name: Cleanup draft file
+        if: steps.check_file.outputs.exists == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "GitHub Actions"
+          
+          git rm patchnote-draft.json
+          git commit -m "Remove patchnote draft after publishing v$NEW_VERSION"
+          git push origin main
+          
+          echo "Removed patchnote-draft.json file"

--- a/.github/workflows/update-patchnote.yml
+++ b/.github/workflows/update-patchnote.yml
@@ -1,0 +1,90 @@
+name: Update Patchnote
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types: [closed]
+
+jobs:
+  update-patchnote:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          
+      - name: Extract PR information
+        id: pr_info
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          
+          if [[ $BRANCH_NAME =~ ^([^/]+)/ ]]; then
+            TYPE="${BASH_REMATCH[1]}"
+          else
+            TYPE="other"
+          fi
+          
+          if [[ $BRANCH_NAME =~ ^[^/]+/(.+)$ ]]; then
+            FEATURE_NAME="${BASH_REMATCH[1]}"
+          else
+            FEATURE_NAME="$BRANCH_NAME"
+          fi
+          
+          echo "type=$TYPE" >> $GITHUB_OUTPUT
+          echo "feature_name=$FEATURE_NAME" >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+          
+      - name: Update patchnote-draft.json
+        run: |
+          TYPE="${{ steps.pr_info.outputs.type }}"
+          FEATURE_NAME="${{ steps.pr_info.outputs.feature_name }}"
+          PR_TITLE="${{ steps.pr_info.outputs.pr_title }}"
+          
+          case "$TYPE" in
+            feature)
+              SECTION="Nouveautés"
+              ;;
+            fix|bugfix|patch)
+              SECTION="Corrections"
+              ;;
+            chore)
+              SECTION="Améliorations techniques"
+              ;;
+            *)
+              SECTION="Autres changements"
+              ;;
+          esac
+          
+          if [ ! -f "patchnote-draft.json" ]; then
+            echo '{
+              "version": "",
+              "title": "Prochaine mise à jour",
+              "emoji": "✨",
+              "sections": {
+                "Nouveautés": [],
+                "Corrections": [],
+                "Améliorations techniques": [],
+                "Autres changements": []
+              }
+            }' > patchnote-draft.json
+          fi
+          
+          jq --arg section "$SECTION" \
+             --arg feature "$FEATURE_NAME" \
+             --arg description "$PR_TITLE" \
+             '.sections[$section] += [{name: $feature, description: $description}]' \
+             patchnote-draft.json > temp.json && mv temp.json patchnote-draft.json
+          
+      - name: Commit updated patchnote draft
+        run: |
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add patchnote-draft.json
+          git commit -m "Update patchnote draft with ${{ steps.pr_info.outputs.feature_name }}" || echo "No changes to commit"
+          git push

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,5 +53,20 @@ services:
         npx prisma db seed
       "
 
+  patchnote-importer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    environment:
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/nextjs_prod
+    volumes:
+      - ./patchnotes:/app/patchnotes
+    depends_on:
+      db-setup:
+        condition: service_completed_successfully
+    restart: "no"
+    command: node /app/scripts/import-patchnotes.js
+
 volumes:
   postgres_data_prod:

--- a/prisma/migrations/20250502085144_init/migration.sql
+++ b/prisma/migrations/20250502085144_init/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "patch_notes" (
+    "id" SERIAL NOT NULL,
+    "version" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "emoji" TEXT,
+    "releaseDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "content" TEXT NOT NULL,
+    "published" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "patch_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "patch_note_views" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "patch_note_id" INTEGER NOT NULL,
+    "viewed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "patch_note_views_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "patch_note_views_user_id_patch_note_id_key" ON "patch_note_views"("user_id", "patch_note_id");
+
+-- AddForeignKey
+ALTER TABLE "patch_note_views" ADD CONSTRAINT "patch_note_views_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "patch_note_views" ADD CONSTRAINT "patch_note_views_patch_note_id_fkey" FOREIGN KEY ("patch_note_id") REFERENCES "patch_notes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,33 @@ enum Role {
   @@map("roles")
 }
 
+model PatchNote {
+  id          Int       @id @default(autoincrement())
+  version     String
+  title       String
+  emoji       String?
+  releaseDate DateTime  @default(now())
+  content     String
+  published   Boolean   @default(false)
+  
+  userViews   PatchNoteView[]
+  
+  @@map("patch_notes")
+}
+
+model PatchNoteView {
+  id          Int       @id @default(autoincrement())
+  userId      Int       @map("user_id")
+  patchNoteId Int       @map("patch_note_id")
+  viewedAt    DateTime  @default(now()) @map("viewed_at")
+  
+  user        User      @relation(fields: [userId], references: [id])
+  patchNote   PatchNote @relation(fields: [patchNoteId], references: [id])
+  
+  @@unique([userId, patchNoteId])
+  @@map("patch_note_views")
+}
+
 model User {
   id           Int          @id @default(autoincrement())
   email        String       @unique
@@ -28,6 +55,7 @@ model User {
   updatedAt    DateTime     @updatedAt @map("updated_at")
   projects     Project[]
   userTasks    UserTask[]
+  patchNoteViews PatchNoteView[]
 
   @@map("users")
 }

--- a/scripts/import-patchnotes.js
+++ b/scripts/import-patchnotes.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function importPatchnotes() {
+  try {
+    console.log('🦥 Starting patchnote import process...');
+    
+    const patchnotesDir = path.join(process.cwd(), 'docs', 'patchnotes');
+    
+    if (!fs.existsSync(patchnotesDir)) {
+      console.log('😡 No patchnotes directory found. Skipping import.');
+      return;
+    }
+    
+    const files = fs.readdirSync(patchnotesDir)
+      .filter(file => file.endsWith('.json'))
+      .sort();
+    
+    console.log(`🔮 Found ${files.length} patchnote files.`);
+    
+    for (const file of files) {
+      const filePath = path.join(patchnotesDir, file);
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+      
+      try {
+        const patchnoteData = JSON.parse(fileContent);
+        const { version, title, emoji, sections } = patchnoteData;
+        
+        const existingPatchnote = await prisma.patchNote.findFirst({
+          where: {
+            version
+          }
+        });
+        
+        if (existingPatchnote) {
+          console.log(`🤖 Patchnote v${version} already exists in the database. Skipping...`);
+          continue;
+        }
+        
+        const newPatchnote = await prisma.patchNote.create({
+          data: {
+            version,
+            title,
+            emoji: emoji || '✨',
+            content: JSON.stringify(sections),
+            published: true
+          }
+        });
+        
+        console.log(`🎉 Successfully imported patchnote v${version} with ID ${newPatchnote.id}`);
+      } catch (parseError) {
+        console.error(`❌ Error parsing patchnote file ${file}:`, parseError);
+      }
+    }
+    
+    console.log('🐶 Patchnote import process completed.');
+  } catch (error) {
+    console.error('❌ Error importing patchnotes:', error);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+importPatchnotes().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces a comprehensive patchnote management system, including workflows for updating and publishing patchnotes, database schema updates, and a script for importing patchnotes into the database. Key changes include the addition of new GitHub Actions workflows, database models for patchnotes, and a Docker service for importing patchnotes.

### Workflow Enhancements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R17): Replaced the trigger mechanism with a dependency on the "Publish Patchnote" workflow and updated deployment steps to streamline production deployment.
* [`.github/workflows/publish-patchnotes.yml`](diffhunk://#diff-e47782773074dd8a753c9b62ecde312b96a0d28be401bfb3e724767d2a264e05R1-R114): Added a new workflow to publish patchnotes when pull requests to the `main` branch are merged. This includes generating version numbers, updating patchnote files, and tagging releases.
* [`.github/workflows/update-patchnote.yml`](diffhunk://#diff-12f1e91eb35b2b26566d2d361073871f8e43cd0f969912cdd9188e74f40a8f38R1-R90): Introduced a workflow to update the draft patchnote file when pull requests to the `dev` branch are merged. It categorizes changes based on branch naming conventions.

### Database Schema Updates:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR21-R47): Added `PatchNote` and `PatchNoteView` models to manage patchnote metadata and user views. Updated the `User` model to include a relation to `PatchNoteView`. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR21-R47) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR58)

### Patchnote Importer:
* [`scripts/import-patchnotes.js`](diffhunk://#diff-fa5b64c031000f936b066ac481b0dd48ddd2d7ebccac54928bdf29988ca1f912R1-R71): Added a script to import patchnotes from JSON files into the database. It ensures no duplicate patchnotes are created and logs the import process.

### Docker Service Addition:
* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R56-R70): Added a new `patchnote-importer` service to run the patchnote import script in the production environment.