### PR TITLE
:wrench: (docker-compose.prod): Add generate commande in patchnote-importer

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,7 +66,7 @@ services:
       db-setup:
         condition: service_completed_successfully
     restart: "no"
-    command: sh -c "node /app/scripts/import-patchnotes.js"
+    command: sh -c "npx prisma generate && node /app/scripts/import-patchnotes.js"
 
 volumes:
   postgres_data_prod:


### PR DESCRIPTION
This pull request modifies the `docker-compose.prod.yml` file to enhance the database setup process by adding a Prisma schema generation step before importing patch notes.

Key change:

* Updated the `db-setup` service's `command` to include `npx prisma generate` before running the script `import-patchnotes.js`. This ensures that the Prisma client is generated before executing the database import. (`[docker-compose.prod.ymlL69-R69](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L69-R69)`)