### PR TITLE
🔨 Add description to patchnotes

### DIFF
--- a/docs/patchnotes/patchnote-draft.json
+++ b/docs/patchnotes/patchnote-draft.json
@@ -1,6 +1,7 @@
 {
   "version": "1.1.1",
   "title": "Ajout de la documentation des patchnotes",
+  "description": "Ajout de la documentation de la feature des `patchnotes`",
   "emoji": "📝",
   "sections": {
     "news": [],

--- a/prisma/migrations/20250502142732_patchnote_description/migration.sql
+++ b/prisma/migrations/20250502142732_patchnote_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "patch_notes" ADD COLUMN     "description" TEXT NOT NULL DEFAULT 'No description for this patchnote';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model PatchNote {
   id          Int       @id @default(autoincrement())
   version     String
   title       String
+  description String    @default("No description for this patchnote")
   emoji       String?
   releaseDate DateTime  @default(now())
   content     String

--- a/scripts/import-patchnotes.js
+++ b/scripts/import-patchnotes.js
@@ -27,7 +27,7 @@ async function importPatchnotes() {
       
       try {
         const patchnoteData = JSON.parse(fileContent);
-        const { version, title, emoji, sections } = patchnoteData;
+        const { version, title, description, emoji, sections } = patchnoteData;
         
         const existingPatchnote = await prisma.patchNote.findFirst({
           where: {
@@ -44,6 +44,7 @@ async function importPatchnotes() {
           data: {
             version,
             title,
+            description,
             emoji: emoji || '✨',
             content: JSON.stringify(sections),
             published: true


### PR DESCRIPTION
This pull request introduces a new `description` field for patch notes, ensuring better documentation and clarity for each patch note entry. The changes span database schema updates, model adjustments, and documentation enhancements.

### Database Schema Updates:
* [`prisma/migrations/20250502142732_patchnote_description/migration.sql`](diffhunk://#diff-e34cbbabfd0e571e5f5bdabe6335b39d075c70d8bfaf50fd474932055efd51c4R1-R2): Added a new `description` column to the `patch_notes` table with a default value of `'No description for this patchnote'`.

### Model Adjustments:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR25): Updated the `PatchNote` model to include a `description` field with a default value of `"No description for this patchnote"`.

### Documentation Enhancements:
* [`docs/patchnotes/patchnote-draft.json`](diffhunk://#diff-5b2b71a4d391cc5e12b08dec79d6c4d356dfa4305f95b7d6369984cd826f635dR4): Added a `description` field in the patch note metadata to document the purpose of the feature.