### PR TITLE
🔨 (patchnotes): Add pull request number

### DIFF
--- a/.github/workflows/update-patchnote.yml
+++ b/.github/workflows/update-patchnote.yml
@@ -90,7 +90,8 @@ jobs:
           jq --arg section "$SECTION" \
              --arg feature "$FEATURE_NAME" \
              --arg description "$PR_TITLE" \
-             '.sections[$section] += [{"name": $feature, "description": $description}]' \
+             --arg pr_number "${{ github.event.pull_request.number }}" \
+             '.sections[$section] += [{"name": $feature, "description": $description, "pr_number": $pr_number}]' \
              docs/patchnotes/patchnote-draft.json > temp.json && mv temp.json docs/patchnotes/patchnote-draft.json
       
       - name: Create Pull Request for patchnote update

--- a/docs/patchnotes.md
+++ b/docs/patchnotes.md
@@ -53,10 +53,11 @@ Le fichier de `docker-compose.prod.yml` contient un service pour **importer dire
 {
   "version": "",
   "title": "Prochaine mise à jour",
+  "description": "Description du patchnote",
   "emoji": "✨",
   "sections": {
     "Nouveautés": [
-      { "name": "feature-name", "description": "Description de la fonctionnalité" }
+      { "name": "feature-name", "description": "Description de la fonctionnalité", "pr_number": 2 }
     ],
     "Corrections": [],
     "Améliorations techniques": [],
@@ -70,10 +71,11 @@ Le fichier de `docker-compose.prod.yml` contient un service pour **importer dire
 {
   "version": "1.2.0",
   "title": "Mise à jour 1.2.0",
+  "description": "Description du patchnote",
   "emoji": "✨",
   "sections": {
     "Nouveautés": [
-      { "name": "feature-name", "description": "Description de la fonctionnalité" }
+      { "name": "feature-name", "description": "Description de la fonctionnalité", "pr_number": 2 }
     ],
     "Corrections": [],
     "Améliorations techniques": [],
@@ -89,6 +91,7 @@ model PatchNote {
   id          Int       @id @default(autoincrement())
   version     String    // Par exemple "1.2.0"
   title       String
+  description String    @default("No description for this patchnote")
   emoji       String?
   releaseDate DateTime  @default(now())
   content     String    // Contenu JSON structuré des notes


### PR DESCRIPTION
This pull request introduces changes to enhance the patch note generation process by adding a description field and associating pull request numbers with features. Additionally, it updates the patch note schema to include a default description field. Below are the most important changes:

### Enhancements to Patch Note Generation:

* [`.github/workflows/update-patchnote.yml`](diffhunk://#diff-12f1e91eb35b2b26566d2d361073871f8e43cd0f969912cdd9188e74f40a8f38L93-R94): Updated the workflow to include the pull request number (`pr_number`) when appending feature details to the patch note draft JSON file.

* [`docs/patchnotes.md`](diffhunk://#diff-c49863f73b06f313bceef246df84d56eb00739dd813e4086970df5271c272d81R56-R60): Updated the patch note examples to include a `description` field and a `pr_number` field for each feature entry. [[1]](diffhunk://#diff-c49863f73b06f313bceef246df84d56eb00739dd813e4086970df5271c272d81R56-R60) [[2]](diffhunk://#diff-c49863f73b06f313bceef246df84d56eb00739dd813e4086970df5271c272d81R74-R78)

### Schema Updates:

* [`docs/patchnotes.md`](diffhunk://#diff-c49863f73b06f313bceef246df84d56eb00739dd813e4086970df5271c272d81R94): Modified the `PatchNote` model to include a new `description` field with a default value of "No description for this patchnote."