### PR TITLE
:hammer: Add notification for new update

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,18 +1,26 @@
-import React from 'react';
-import { User, LogOut } from 'lucide-react';
+import { ReactNode } from 'react';
+import { User, LogOut, Bell } from 'lucide-react';
 import Sidebar from '@/components/layout/Sidebar';
 import { logout } from '@/action/auth/logout';
 import { redirect } from 'next/navigation';
 import { getUserLoggedIn } from '@/action/users/getUserLoggedIn';
 import PatchnoteChecker from '@/components/patchnote/PatchnoteChecker';
+import { checkUnreadPatchnotes } from '@/action/patchnote/patchnote';
+import PatchnotesDropdown from '@/components/patchnote/PatchnotesDropdown';
 
 export default async function DashboardLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
 
   const user = await getUserLoggedIn();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const unreadPatchnotes = await checkUnreadPatchnotes(user?.id);
 
   async function handleLogout() {
     "use server";
@@ -38,12 +46,7 @@ export default async function DashboardLayout({
 
           {/* User actions */}
           <div className="flex items-center gap-4">
-            {/*
-            <button className="p-2 rounded-md text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors relative">
-              <Bell className="h-5 w-5" />
-              <span className="absolute top-1 right-1 w-2 h-2 bg-indigo-500 rounded-full"></span>
-            </button>
-            */}
+            <PatchnotesDropdown patchnotes={unreadPatchnotes} />
 
             <div className="flex items-center gap-3">
               <div className="flex flex-col items-end">

--- a/src/components/patchnote/PatchnoteChecker.tsx
+++ b/src/components/patchnote/PatchnoteChecker.tsx
@@ -1,20 +1,19 @@
 import { checkUnreadPatchnotes, markPatchnoteAsRead } from '@/action/patchnote/patchnote';
 import { getUserLoggedIn } from '@/action/users/getUserLoggedIn';
 import PatchnoteModalContainer from './PatchnoteModalContainer';
+import { redirect } from 'next/navigation';
 
 // This component is rendered in the dashboard layout
 export default async function PatchnoteChecker() {
-  // Get the currently logged in user
   const user = await getUserLoggedIn();
   
   if (!user) {
-    return null;
+    return redirect('/login');
   }
   
-  // Check if the user has any unread patchnotes
   const unreadPatchnote = await checkUnreadPatchnotes(user.id);
   console.log('unreadPatchnote', unreadPatchnote);
-  // If there are no unread patchnotes, don't render anything
+
   if (!unreadPatchnote) {
     return null;
   }

--- a/src/components/patchnote/PatchnoteIndicator.tsx
+++ b/src/components/patchnote/PatchnoteIndicator.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Bell } from 'lucide-react';
+
+interface PatchnoteIndicatorProps {
+  count: number;
+  isCollapsed?: boolean;
+}
+
+export default function PatchnoteIndicator({ count, isCollapsed = false }: PatchnoteIndicatorProps) {
+  // Don't render anything if there are no unread patchnotes
+  if (count <= 0) {
+    return null;
+  }
+
+  return (
+    <Link
+      href="/dashboard/patchnotes"
+      className={`flex items-center gap-3 px-3 py-2 mx-2 mb-1 rounded-md transition-all ${
+        isCollapsed ? 'justify-center' : ''
+      } bg-indigo-500/20 text-indigo-400 hover:bg-indigo-500/30 hover:text-indigo-300 relative`}
+    >
+      <motion.div
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.95 }}
+        transition={{ duration: 0.1 }}
+        className="relative"
+      >
+        <Bell className="h-5 w-5" />
+        <motion.span
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-rose-500 text-[10px] font-bold text-white"
+        >
+          {count > 9 ? '9+' : count}
+        </motion.span>
+      </motion.div>
+
+      {!isCollapsed && (
+        <motion.span
+          className="font-medium"
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -10 }}
+          transition={{ duration: 0.2 }}
+        >
+          Nouvelles mises à jour
+        </motion.span>
+      )}
+    </Link>
+  );
+}

--- a/src/components/patchnote/PatchnotesDropdown.tsx
+++ b/src/components/patchnote/PatchnotesDropdown.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Bell } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { PatchNote } from './PatchnoteModal';
+import { markPatchnoteAsRead } from '@/action/patchnote/patchnote';
+import { useRouter } from 'next/navigation';
+
+interface PatchnotesDropdownProps {
+  patchnotes: PatchNote[];
+}
+
+export default function PatchnotesDropdown({ patchnotes }: PatchnotesDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // Format release date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    });
+  };
+
+  const handlePatchnoteClick = async (patchnoteId: number) => {
+    setIsOpen(false);
+    
+    // Mark the patchnote as read when clicked
+    try {
+      await markPatchnoteAsRead(patchnoteId, 0); // The second argument will be replaced server-side
+      router.refresh(); // Refresh the page to update the unread count
+    } catch (error) {
+      console.error('Error marking patchnote as read:', error);
+    }
+  };
+
+  const hasUnreadPatchnotes = patchnotes?.length > 0;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="p-2 rounded-md text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors relative cursor-pointer"
+        aria-label="Notifications"
+      >
+        <Bell className="h-5 w-5" />
+        {hasUnreadPatchnotes && (
+          <span className="absolute top-1 right-1 w-2 h-2 bg-indigo-500 rounded-full"></span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, y: 10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.2 }}
+            className="absolute right-0 mt-2 w-80 max-h-[70vh] overflow-auto bg-zinc-900 rounded-lg border border-zinc-800 shadow-xl z-50"
+          >
+            <div className="p-3 border-b border-zinc-800">
+              <h3 className="font-medium text-zinc-200">Nouvelles mises à jour</h3>
+              {hasUnreadPatchnotes && (
+                <p className="text-xs text-zinc-400 mt-1">
+                  {patchnotes.length} note{patchnotes.length > 1 ? 's' : ''} de mise à jour non lue{patchnotes.length > 1 ? 's' : ''}
+                </p>
+              )}
+            </div>
+
+            <div className="py-2">
+              {hasUnreadPatchnotes ? (
+                patchnotes.map((note) => (
+                  <motion.div
+                    key={note.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.1 }}
+                    className="px-3 py-2 hover:bg-zinc-800 cursor-pointer transition-colors"
+                    onClick={() => handlePatchnoteClick(note.id)}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center text-indigo-400">
+                        <span>{note.emoji || '✨'}</span>
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-zinc-200 flex items-center gap-2">
+                          {note.title}
+                          <span className="text-xs px-1.5 py-0.5 bg-indigo-500/20 text-indigo-400 rounded-full">
+                            v{note.version}
+                          </span>
+                        </p>
+                        <p className="text-xs text-zinc-400 truncate mt-0.5">{note.description}</p>
+                        <p className="text-xs text-zinc-500 mt-1">{formatDate(note.releaseDate)}</p>
+                      </div>
+                    </div>
+                  </motion.div>
+                ))
+              ) : (
+                <div className="px-4 py-6 text-center">
+                  <p className="text-sm text-zinc-400">Aucune mise à jour non lue</p>
+                </div>
+              )}
+            </div>
+            
+            {hasUnreadPatchnotes && (
+              <div className="p-2 border-t border-zinc-800">
+                <button 
+                  className="w-full py-2 px-3 bg-indigo-600 hover:bg-indigo-700 rounded-md text-sm font-medium transition-colors"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Marquer tout comme lu
+                </button>
+              </div>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+} 


### PR DESCRIPTION
This pull request introduces a new notification system for unread patchnotes in the dashboard, enhancing user experience by providing visual indicators and dropdown functionality. The changes include updates to the dashboard layout, new components for notifications, and improved user redirection logic.

### Notification System Enhancements:

* **Added `PatchnotesDropdown` Component**: A dropdown menu for displaying unread patchnotes with animations, click-to-mark-read functionality, and a "Mark all as read" button.
* **Introduced `PatchnoteIndicator` Component**: A visual indicator for unread patchnotes, displaying a notification badge with the count of unread items.

### Dashboard Layout Updates:

* **Integrated Notification Components**: Replaced the placeholder notification button with the `PatchnotesDropdown` component in the `DashboardLayout`. [[1]](diffhunk://#diff-45ed63d085d7e28662693790d7371503bd5a061b9ff777fc76b4a7b8bdb08826L1-R24) [[2]](diffhunk://#diff-45ed63d085d7e28662693790d7371503bd5a061b9ff777fc76b4a7b8bdb08826L41-R49)
* **User Redirection Logic**: Added logic to redirect unauthenticated users to the login page in both `DashboardLayout` and `PatchnoteChecker`. [[1]](diffhunk://#diff-45ed63d085d7e28662693790d7371503bd5a061b9ff777fc76b4a7b8bdb08826L1-R24) [[2]](diffhunk://#diff-3c1dbabcff00db0daf293e959dc533339cd1d7c053927a682cc860f750e48a33R4-R16)

These changes collectively improve the notification experience and ensure proper user authentication handling in the dashboard.