### PR TITLE
:adhesive_bandage: (patchnote): Link PatchNotesDropdown to PatchNotePage

### DIFF
--- a/src/components/patchnote/PatchnoteModal.tsx
+++ b/src/components/patchnote/PatchnoteModal.tsx
@@ -151,7 +151,11 @@ export default function PatchNoteModal({
                   <h3 className="text-xl font-bold text-white">{patchNote.title}</h3>
                   <div className="flex items-center gap-2 mt-1">
                     <p className="text-sm text-zinc-400">
-                      {formatDate(patchNote.releaseDate.toISOString())}
+                      {new Date(patchNote.releaseDate).toLocaleDateString('fr-FR', {
+                        day: 'numeric',
+                        month: 'long',
+                        year: 'numeric'
+                      })}
                     </p>
                     {totalPatchnotesCount > 1 && (
                       <>

--- a/src/components/patchnote/PatchnoteModalContainer.tsx
+++ b/src/components/patchnote/PatchnoteModalContainer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import PatchNoteModal, { PatchNote } from './PatchnoteModal';
+import PatchNoteModal from './PatchnoteModal';
+import { PatchNote } from '@prisma/client';
 
 interface PatchnoteModalContainerProps {
   patchnote: PatchNote[];

--- a/src/components/patchnote/PatchnotesDropdown.tsx
+++ b/src/components/patchnote/PatchnotesDropdown.tsx
@@ -3,9 +3,10 @@
 import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { PatchNote } from './PatchnoteModal';
+import { PatchNote } from '@prisma/client';
 import { markPatchnoteAsRead } from '@/action/patchnote/patchnote';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 interface PatchnotesDropdownProps {
   patchnotes: PatchNote[];
@@ -88,30 +89,36 @@ export default function PatchnotesDropdown({ patchnotes }: PatchnotesDropdownPro
             <div className="py-2">
               {hasUnreadPatchnotes ? (
                 patchnotes.map((note) => (
-                  <motion.div
-                    key={note.id}
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.1 }}
-                    className="px-3 py-2 hover:bg-zinc-800 cursor-pointer transition-colors"
-                    onClick={() => handlePatchnoteClick(note.id)}
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center text-indigo-400">
-                        <span>{note.emoji || '✨'}</span>
+                  <Link href={`/dashboard/patchnotes/${note.id}`} key={note.id}>
+                    <motion.div
+                      key={note.id}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.1 }}
+                      className="px-3 py-2 hover:bg-zinc-800 cursor-pointer transition-colors"
+                      onClick={() => handlePatchnoteClick(note.id)}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-500/20 flex items-center justify-center text-indigo-400">
+                          <span>{note.emoji || '✨'}</span>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-zinc-200 flex items-center gap-2">
+                            {note.title}
+                            <span className="text-xs px-1.5 py-0.5 bg-indigo-500/20 text-indigo-400 rounded-full">
+                              v{note.version}
+                            </span>
+                          </p>
+                          <p className="text-xs text-zinc-400 truncate mt-0.5">{note.description}</p>
+                          <p className="text-xs text-zinc-500 mt-1">{new Date(note.releaseDate).toLocaleDateString('fr-FR', {
+                            day: 'numeric',
+                            month: 'long',
+                            year: 'numeric'
+                          })}</p>
+                        </div>
                       </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-zinc-200 flex items-center gap-2">
-                          {note.title}
-                          <span className="text-xs px-1.5 py-0.5 bg-indigo-500/20 text-indigo-400 rounded-full">
-                            v{note.version}
-                          </span>
-                        </p>
-                        <p className="text-xs text-zinc-400 truncate mt-0.5">{note.description}</p>
-                        <p className="text-xs text-zinc-500 mt-1">{formatDate(note.releaseDate)}</p>
-                      </div>
-                    </div>
-                  </motion.div>
+                    </motion.div>
+                  </Link>
                 ))
               ) : (
                 <div className="px-4 py-6 text-center">


### PR DESCRIPTION
This pull request introduces updates to the patch note components, including formatting changes for release dates, adjustments to imports, and the addition of navigation links to individual patch notes. These changes aim to improve the user experience and maintain consistency in the codebase.

### Date Formatting Updates:
* Updated the release date formatting in `PatchNoteModal` to use `toLocaleDateString` with the `fr-FR` locale for a more user-friendly display. (`src/components/patchnote/PatchnoteModal.tsx`)
* Applied the same `toLocaleDateString` formatting to release dates in `PatchnotesDropdown`. (`src/components/patchnote/PatchnotesDropdown.tsx`)

### Import Adjustments:
* Replaced local imports of the `PatchNote` type with imports from `@prisma/client` in `PatchnoteModalContainer` and `PatchnotesDropdown` for consistency and type accuracy. (`src/components/patchnote/PatchnoteModalContainer.tsx`, `src/components/patchnote/PatchnotesDropdown.tsx`) [[1]](diffhunk://#diff-edcb8d9d2ac0fe604b97e2b3091c1304a9c651b766c3d1f025aab74d51fcd6f4L4-R5) [[2]](diffhunk://#diff-bfd859a3636598b1c75992c7f591d3185127f177c5d905982d5e362faa7bc589L6-R9)

### Navigation Enhancements:
* Added `Link` components in `PatchnotesDropdown` to enable navigation to individual patch note pages, improving accessibility. (`src/components/patchnote/PatchnotesDropdown.tsx`) [[1]](diffhunk://#diff-bfd859a3636598b1c75992c7f591d3185127f177c5d905982d5e362faa7bc589R92) [[2]](diffhunk://#diff-bfd859a3636598b1c75992c7f591d3185127f177c5d905982d5e362faa7bc589L111-R121)