### PR TITLE
:lipstick: (patchnotes): Add patchnotes page to see all patchnotes

### DIFF
--- a/src/app/dashboard/patchnotes/PatchnoteList.tsx
+++ b/src/app/dashboard/patchnotes/PatchnoteList.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Search, Calendar, ChevronRight, ArrowRight, Filter, Newspaper, Bug, Wrench, Plus } from 'lucide-react';
+import { PatchNote } from '@prisma/client';
+import { PatchNoteSection } from '@/components/patchnote/PatchnoteModal';
+
+// Animation variants
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.05,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: 'spring',
+      stiffness: 100,
+      damping: 15,
+    },
+  },
+};
+
+interface PatchnoteListProps {
+  patchnotes: PatchNote[];
+}
+
+export default function PatchnoteList({ patchnotes }: PatchnoteListProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedYear, setSelectedYear] = useState<string | null>(null);
+  
+  // Extract years from patchnotes for filtering
+  const years = [...new Set(patchnotes.map(note => 
+    new Date(note.releaseDate).getFullYear().toString()
+  ))].sort((a, b) => parseInt(b) - parseInt(a)); // Sort descending
+  
+  // Filter patchnotes based on search and year
+  const filteredPatchnotes = patchnotes.filter(note => {
+    const matchesSearch = searchQuery.trim() === '' || 
+      note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      note.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      note.version.toLowerCase().includes(searchQuery.toLowerCase());
+      
+    const matchesYear = selectedYear === null || 
+      new Date(note.releaseDate).getFullYear().toString() === selectedYear;
+      
+    return matchesSearch && matchesYear;
+  });
+  
+  // Group patchnotes by month
+  const groupedPatchnotes = filteredPatchnotes.reduce((groups: Record<string, PatchNote[]>, note) => {
+    const date = new Date(note.releaseDate);
+    const monthYear = `${date.toLocaleString('fr-FR', { month: 'long' })} ${date.getFullYear()}`;
+    
+    if (!groups[monthYear]) {
+      groups[monthYear] = [];
+    }
+    
+    groups[monthYear].push(note);
+    return groups;
+  }, {});
+  
+  // Sort months in descending order (newest first)
+  const sortedMonths = Object.keys(groupedPatchnotes).sort((a, b) => {
+    const dateA = new Date(parseInt(a.split(' ')[1]), getMonthIndex(a.split(' ')[0]));
+    const dateB = new Date(parseInt(b.split(' ')[1]), getMonthIndex(b.split(' ')[0]));
+    return dateB.getTime() - dateA.getTime();
+  });
+  
+  // Helper to get month index from French month name
+  function getMonthIndex(monthName: string): number {
+    const months = [
+      'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+      'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'
+    ];
+    return months.indexOf(monthName.toLowerCase());
+  }
+   
+  return (
+    <div className="space-y-6">
+      {/* Search and filters */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+        <div className="flex flex-col md:flex-row gap-4">
+          {/* Search box */}
+          <div className="relative flex-grow">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Search className="h-5 w-5 text-zinc-500" />
+            </div>
+            <input
+              type="text"
+              placeholder="Rechercher des notes de mise à jour..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+          
+          {/* Year filter */}
+          <div className="relative min-w-40">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Calendar className="h-5 w-5 text-zinc-500" />
+            </div>
+            <select
+              value={selectedYear || ''}
+              onChange={(e) => setSelectedYear(e.target.value || null)}
+              className="appearance-none w-full pl-10 pr-8 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            >
+              <option value="">Toutes les années</option>
+              {years.map(year => (
+                <option key={year} value={year}>{year}</option>
+              ))}
+            </select>
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+              <ChevronRight className="h-5 w-5 text-zinc-500 rotate-90" />
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      {/* Patchnotes list */}
+      {filteredPatchnotes.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 bg-zinc-900 border border-zinc-800 rounded-xl">
+          <div className="p-4 rounded-full bg-zinc-800 mb-4">
+            <Search className="h-6 w-6 text-zinc-500" />
+          </div>
+          <h3 className="text-lg font-medium text-white mb-2">Aucun résultat</h3>
+          <p className="text-zinc-400 max-w-md text-center">
+            Aucune note de mise à jour ne correspond à votre recherche.
+            Essayez de modifier vos critères de recherche.
+          </p>
+        </div>
+      ) : (
+        <motion.div
+          variants={containerVariants}
+          initial="hidden"
+          animate="visible"
+          className="space-y-8"
+        >
+          {sortedMonths.map(month => (
+            <div key={month} className="space-y-4">
+              <h2 className="text-lg font-medium text-white flex items-center gap-2">
+                <Calendar className="h-5 w-5 text-indigo-400" />
+                {month}
+              </h2>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {groupedPatchnotes[month].map((note, index) => (
+                  <motion.div
+                    key={note.id}
+                    variants={itemVariants}
+                    className="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl overflow-hidden transition-colors"
+                  >
+                    <Link href={`/dashboard/patchnotes/${note.id}`} className="block">
+                      <div className="p-5">
+                        <div className="flex justify-between items-start mb-3">
+                          <div className="flex items-center gap-3">
+                            <div className="h-10 w-10 flex items-center justify-center rounded-full bg-indigo-500/20 text-indigo-400 text-xl">
+                              {note.emoji || '✨'}
+                            </div>
+                            <div>
+                              <h3 className="font-medium text-white">{note.title}</h3>
+                              <p className="text-sm text-zinc-400">{new Date(note.releaseDate).toLocaleDateString('fr-FR', {
+                                day: 'numeric',
+                                month: 'long',
+                                year: 'numeric'
+                              })}</p>
+                            </div>
+                          </div>
+                          
+                          <div className="px-2.5 py-1 rounded-full bg-indigo-500/10 text-indigo-400 text-xs font-medium">
+                            v{note.version}
+                          </div>
+                        </div>
+                        
+                        {note.description && (
+                          <p className="text-sm text-zinc-300 mb-4 line-clamp-2">{note.description}</p>
+                        )}
+                        
+                        <div className="flex items-center justify-between">
+                          {/* Count changes */}
+                          <div className="flex gap-3">
+                            {note.content && Object.entries(JSON.parse(note.content)).map(([key, items]: [string, unknown]) => {
+                              const itemsArray = items as PatchNoteSection[];
+
+                              console.info("--------------------------------");
+                              console.info("note.content", JSON.parse(note.content));
+                              console.info("Object.entries(JSON.parse(note.content))", Object.entries(JSON.parse(note.content)));
+
+                              console.log("itemsArray", itemsArray);
+                              // Skip empty sections
+                              if (!itemsArray || itemsArray.length === 0) return null;
+                              
+                              // Determine icon and color based on section key
+                              const getIconColor = (sectionKey: string) => {
+                                switch(sectionKey) {
+                                  case 'news': return 'text-emerald-400 bg-emerald-500/10';
+                                  case 'corrections': return 'text-amber-400 bg-amber-500/10';
+                                  case 'technical-improvements': return 'text-indigo-400 bg-indigo-500/10';
+                                  case 'other-changes': return 'text-purple-400 bg-purple-500/10';
+                                  default: return 'text-zinc-400 bg-zinc-500/10';
+                                }
+                              };
+
+                              const getIcon = (sectionKey: string) => {
+                                switch(sectionKey) {
+                                  case 'news': return <Newspaper className="h-3 w-3" />;
+                                  case 'corrections': return <Bug className="h-3 w-3" />;
+                                  case 'technical-improvements': return <Wrench className="h-3 w-3" />;
+                                  case 'other-changes': return <Plus className="h-3 w-3" />;
+                                }
+                              };
+                              
+                              const colors = getIconColor(key);
+                              
+                              return (
+                                <div 
+                                  key={key} 
+                                  className={`px-2 py-1 rounded-md text-xs font-medium flex items-center gap-1 ${colors}`}
+                                  title={itemsArray[0].name || key}
+                                >
+                                  {getIcon(key)}
+                                  <span>{itemsArray.length}</span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                          
+                          <div className="flex items-center text-indigo-400 text-sm gap-1 group">
+                            <span className="group-hover:underline">Voir les détails</span>
+                            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                          </div>
+                        </div>
+                      </div>
+                    </Link>
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/patchnotes/PatchnoteListSkeleton.tsx
+++ b/src/app/dashboard/patchnotes/PatchnoteListSkeleton.tsx
@@ -1,0 +1,65 @@
+export default function PatchnoteListSkeleton() {
+    return (
+      <div className="space-y-6">
+        {/* Search and filters skeleton */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="h-10 w-full bg-zinc-800 rounded-lg animate-pulse"></div>
+            <div className="h-10 w-full md:w-40 bg-zinc-800 rounded-lg animate-pulse"></div>
+          </div>
+        </div>
+        
+        {/* Two month groups with notes */}
+        {Array.from({ length: 2 }).map((_, groupIndex) => (
+          <div key={groupIndex} className="space-y-4">
+            {/* Month header */}
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-5 bg-zinc-800 rounded-full animate-pulse"></div>
+              <div className="h-7 w-36 bg-zinc-800 rounded-md animate-pulse"></div>
+            </div>
+            
+            {/* Notes grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {Array.from({ length: groupIndex === 0 ? 3 : 2 }).map((_, noteIndex) => (
+                <div 
+                  key={noteIndex}
+                  className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden"
+                  style={{ animationDelay: `${(groupIndex * 3 + noteIndex) * 0.1}s` }}
+                >
+                  <div className="p-5">
+                    {/* Header */}
+                    <div className="flex justify-between items-start mb-3">
+                      <div className="flex items-center gap-3">
+                        <div className="h-10 w-10 rounded-full bg-zinc-800 animate-pulse"></div>
+                        <div>
+                          <div className="h-5 w-32 bg-zinc-800 rounded-md animate-pulse mb-2"></div>
+                          <div className="h-4 w-24 bg-zinc-800 rounded-md animate-pulse"></div>
+                        </div>
+                      </div>
+                      
+                      <div className="h-6 w-16 bg-zinc-800 rounded-full animate-pulse"></div>
+                    </div>
+                    
+                    {/* Description */}
+                    <div className="h-4 w-full bg-zinc-800 rounded-md animate-pulse mb-2"></div>
+                    <div className="h-4 w-2/3 bg-zinc-800 rounded-md animate-pulse mb-4"></div>
+                    
+                    {/* Footer */}
+                    <div className="flex items-center justify-between">
+                      <div className="flex gap-2">
+                        {Array.from({ length: 3 }).map((_, i) => (
+                          <div key={i} className="h-6 w-10 bg-zinc-800 rounded-md animate-pulse"></div>
+                        ))}
+                      </div>
+                      
+                      <div className="h-5 w-28 bg-zinc-800 rounded-md animate-pulse"></div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }

--- a/src/app/dashboard/patchnotes/page.tsx
+++ b/src/app/dashboard/patchnotes/page.tsx
@@ -1,0 +1,40 @@
+import { Suspense } from 'react';
+import { getAllPatchnotes } from '@/action/patchnote/patchnote';
+import PatchnoteList from './PatchnoteList';
+import PatchnoteListSkeleton from './PatchnoteListSkeleton';
+
+export default function PatchnotesPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Notes de mise à jour</h1>
+        <p className="text-zinc-400">Découvrez toutes les nouveautés et améliorations de Splane</p>
+      </div>
+      
+      <Suspense fallback={<PatchnoteListSkeleton />}>
+        <PatchnoteContent />
+      </Suspense>
+    </div>
+  );
+}
+
+async function PatchnoteContent() {
+  const patchnotes = await getAllPatchnotes();
+  
+  if (patchnotes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 bg-zinc-900 border border-zinc-800 rounded-xl">
+        <div className="p-4 rounded-full bg-zinc-800 mb-4">
+          <span className="text-3xl">📝</span>
+        </div>
+        <h3 className="text-lg font-medium text-white mb-2">Aucune note de mise à jour</h3>
+        <p className="text-zinc-400 max-w-md text-center">
+          Les notes de mise à jour apparaîtront ici lorsque de nouvelles fonctionnalités ou 
+          améliorations seront déployées.
+        </p>
+      </div>
+    );
+  }
+  
+  return <PatchnoteList patchnotes={patchnotes} />;
+}


### PR DESCRIPTION
This pull request introduces a new patch notes feature for the dashboard, including a dynamic list of patch notes, skeleton loading states, and a fallback for when no patch notes are available. The changes focus on enhancing user experience with animations, filtering, and grouping capabilities.

### Patch Notes List and Filtering

* Added `PatchnoteList` component to display patch notes with search and year-based filtering. It includes animations for smooth transitions and groups patch notes by month. (`src/app/dashboard/patchnotes/PatchnoteList.tsx`, [src/app/dashboard/patchnotes/PatchnoteList.tsxR1-R254](diffhunk://#diff-cc5505eedc1bcc129b5d058339d10847d9c06bad31754122c9db65c5c516df34R1-R254))

### Skeleton Loading State

* Introduced `PatchnoteListSkeleton` component to provide a loading state with animated placeholders, enhancing the user experience during data fetching. (`src/app/dashboard/patchnotes/PatchnoteListSkeleton.tsx`, [src/app/dashboard/patchnotes/PatchnoteListSkeleton.tsxR1-R65](diffhunk://#diff-9b94f86ebe9d5313fdcf7627f4fc3754fa498fe2afcd2ff93bd86b7acb356477R1-R65))

### Integration into the Dashboard

* Updated the `PatchnotesPage` to use the new `PatchnoteList` and `PatchnoteListSkeleton` components. Added a fallback UI for when no patch notes are available. (`src/app/dashboard/patchnotes/page.tsx`, [src/app/dashboard/patchnotes/page.tsxR1-R40](diffhunk://#diff-29784981b26ab66344f3ae0664e15480e16386ba32cd5cd11d0f706334d8dcc0R1-R40))