### PR TITLE
:hammer: (settings/patchnote): Make patchnote settings functional

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -74,7 +74,7 @@ export default async function DashboardLayout({
           [&::-webkit-scrollbar-thumb]:bg-zinc-700 
           [&::-webkit-scrollbar-thumb:hover]:bg-indigo-600"
         >
-          <PatchnoteChecker />
+          {user.settings.notifications_patch_notes ? <PatchnoteChecker /> : null}
 
           {children}
         </main>


### PR DESCRIPTION
This pull request introduces a conditional rendering change to the `DashboardLayout` component in `src/app/dashboard/layout.tsx`. The change ensures that the `PatchnoteChecker` component is only rendered if the user's settings enable patch note notifications.

* [`src/app/dashboard/layout.tsx`](diffhunk://#diff-45ed63d085d7e28662693790d7371503bd5a061b9ff777fc76b4a7b8bdb08826L77-R77): Updated the `DashboardLayout` component to conditionally render the `PatchnoteChecker` component based on the `user.settings.notifications_patch_notes` property.