### PR TITLE
:lipstick: (style/global.css): Add a cursor pointer for all button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+button {
+    cursor: pointer;
+}


### PR DESCRIPTION
This pull request includes a small change to the `globals.css` file. It adds a CSS rule to ensure that all `button` elements have a `pointer` cursor by default.