### PR TITLE
✨ Add activity feed

### DIFF
--- a/prisma/migrations/20250514165037_add_activity_model/migration.sql
+++ b/prisma/migrations/20250514165037_add_activity_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateEnum
+CREATE TYPE "ActivityType" AS ENUM ('TASK_CREATED', 'TASK_COMPLETED', 'TASK_STARTED', 'PROJECT_CREATED', 'PROJECT_UPDATED');
+
+-- CreateTable
+CREATE TABLE "activities" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "type" "ActivityType" NOT NULL,
+    "content" TEXT NOT NULL,
+    "entity_id" INTEGER NOT NULL,
+    "entity_type" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activities_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "activities" ADD CONSTRAINT "activities_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model User {
   userTasks    UserTask[]
   patchNoteViews PatchNoteView[]
   settings     UserSettings?
+  activities   Activity[]
 
   @@map("users")
 }
@@ -122,4 +123,26 @@ model UserTask {
 
   @@unique([userId, taskId])
   @@map("user_tasks")
+}
+
+enum ActivityType {
+  TASK_CREATED
+  TASK_COMPLETED
+  TASK_STARTED
+  PROJECT_CREATED
+  PROJECT_UPDATED
+}
+
+model Activity {
+  id          Int         @id @default(autoincrement())
+  userId      Int         @map("user_id")
+  type        ActivityType
+  content     String
+  entityId    Int         @map("entity_id")
+  entityType  String      @map("entity_type")
+  createdAt   DateTime    @default(now()) @map("created_at")
+  
+  user        User        @relation(fields: [userId], references: [id])
+
+  @@map("activities")
 }

--- a/src/action/activity/__tests__/getRecentActivity.test.ts
+++ b/src/action/activity/__tests__/getRecentActivity.test.ts
@@ -1,0 +1,230 @@
+import { getRecentActivity } from '@/action/activity/getRecentActivity';
+import { prisma } from '@/lib/prisma';
+import { formatDistanceToNow } from 'date-fns';
+import { fr } from 'date-fns/locale';
+
+// Mock des dépendances
+jest.mock('date-fns', () => ({
+  formatDistanceToNow: jest.fn(),
+}));
+
+jest.mock('date-fns/locale', () => ({
+  fr: {},
+}));
+
+jest.mock('@/lib/prisma', () => {
+  const mockFindMany = jest.fn();
+
+  return {
+    prisma: {
+      activity: {
+        findMany: mockFindMany,
+      },
+    },
+  };
+});
+
+describe('getRecentActivity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return activities with correct format', async () => {
+    // Mock de la date formatée
+    (formatDistanceToNow as jest.Mock).mockReturnValue('il y a 2 heures');
+
+    // Mock des données d'activité
+    const mockActivities = [
+      {
+        id: 1,
+        userId: 1,
+        type: 'TASK_COMPLETED',
+        content: 'a terminé la tâche Create API endpoints',
+        entityId: 123,
+        entityType: 'task',
+        createdAt: new Date('2023-01-01T10:00:00Z'),
+        user: {
+          id: 1,
+          fullName: 'John Doe',
+        },
+      },
+      {
+        id: 2,
+        userId: 2,
+        type: 'TASK_STARTED',
+        content: 'a commencé la tâche Implement responsive layout',
+        entityId: 456,
+        entityType: 'task',
+        createdAt: new Date('2023-01-01T08:00:00Z'),
+        user: {
+          id: 2,
+          fullName: 'Jane Smith',
+        },
+      },
+    ];
+
+    (prisma.activity.findMany as jest.Mock).mockResolvedValue(mockActivities);
+
+    const result = await getRecentActivity(2);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 1,
+      userInitials: 'JD',
+      userName: 'John Doe',
+      content: 'a terminé la tâche Create API endpoints',
+      timeAgo: 'il y a 2 heures',
+      userColor: 'primary',
+    });
+
+    expect(result[1]).toEqual({
+      id: 2,
+      userInitials: 'JS',
+      userName: 'Jane Smith',
+      content: 'a commencé la tâche Implement responsive layout',
+      timeAgo: 'il y a 2 heures',
+      userColor: 'accent',
+    });
+
+    // Vérifier que prisma.activity.findMany a été appelé avec les bons paramètres
+    expect(prisma.activity.findMany).toHaveBeenCalledWith({
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 2,
+    });
+
+    // Vérifier que formatDistanceToNow a été appelé pour chaque activité
+    expect(formatDistanceToNow).toHaveBeenCalledTimes(2);
+    expect(formatDistanceToNow).toHaveBeenCalledWith(mockActivities[0].createdAt, {
+      addSuffix: true,
+      locale: fr,
+    });
+    expect(formatDistanceToNow).toHaveBeenCalledWith(mockActivities[1].createdAt, {
+      addSuffix: true,
+      locale: fr,
+    });
+  });
+
+  it('should use default limit of 3 when no limit is provided', async () => {
+    // Mock des données d'activité
+    (prisma.activity.findMany as jest.Mock).mockResolvedValue([]);
+    (formatDistanceToNow as jest.Mock).mockReturnValue('il y a 1 jour');
+
+    await getRecentActivity();
+
+    // Vérifier que prisma.activity.findMany a été appelé avec la limite par défaut
+    expect(prisma.activity.findMany).toHaveBeenCalledWith({
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 3,
+    });
+  });
+
+  it('should handle unknown activity types correctly', async () => {
+    // Mock de la date formatée
+    (formatDistanceToNow as jest.Mock).mockReturnValue('il y a 3 heures');
+
+    // Mock d'une activité avec un type inconnu
+    const mockActivities = [
+      {
+        id: 3,
+        userId: 3,
+        type: 'UNKNOWN_TYPE',
+        content: 'a fait quelque chose',
+        entityId: 789,
+        entityType: 'unknown',
+        createdAt: new Date('2023-01-01T07:00:00Z'),
+        user: {
+          id: 3,
+          fullName: 'Admin User',
+        },
+      },
+    ];
+
+    (prisma.activity.findMany as jest.Mock).mockResolvedValue(mockActivities);
+
+    const result = await getRecentActivity();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 3,
+      userInitials: 'AU',
+      userName: 'Admin User',
+      content: 'a fait quelque chose',
+      timeAgo: 'il y a 3 heures',
+      userColor: 'primary', // Devrait utiliser la couleur par défaut
+    });
+  });
+
+  it('should handle database errors gracefully', async () => {
+    // Mock d'une erreur de base de données
+    (prisma.activity.findMany as jest.Mock).mockRejectedValue(new Error('Database error'));
+
+    // Capture la console.error
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    // La fonction devrait retourner un tableau vide en cas d'erreur
+    const result = await getRecentActivity();
+
+    expect(result).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Erreur lors de la récupération des activités:',
+      expect.any(Error)
+    );
+  });
+
+  it('should correctly generate initials from user names', async () => {
+    // Mock de la date formatée
+    (formatDistanceToNow as jest.Mock).mockReturnValue('il y a 1 jour');
+
+    // Mock des données d'activité avec différents formats de noms
+    const mockActivities = [
+      {
+        id: 1,
+        userId: 1,
+        type: 'PROJECT_CREATED',
+        content: 'a créé un nouveau projet',
+        entityId: 123,
+        entityType: 'project',
+        createdAt: new Date('2023-01-01T10:00:00Z'),
+        user: {
+          id: 1,
+          fullName: 'John',
+        },
+      },
+      {
+        id: 2,
+        userId: 2,
+        type: 'PROJECT_UPDATED',
+        content: 'a mis à jour le projet',
+        entityId: 456,
+        entityType: 'project',
+        createdAt: new Date('2023-01-01T08:00:00Z'),
+        user: {
+          id: 2,
+          fullName: 'Jane Middle Smith',
+        },
+      },
+    ];
+
+    (prisma.activity.findMany as jest.Mock).mockResolvedValue(mockActivities);
+
+    const result = await getRecentActivity();
+
+    expect(result[0].userInitials).toBe('J');
+    expect(result[1].userInitials).toBe('JMS');
+  });
+});

--- a/src/action/activity/getRecentActivity.ts
+++ b/src/action/activity/getRecentActivity.ts
@@ -1,0 +1,56 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { formatDistanceToNow } from 'date-fns';
+import { fr } from 'date-fns/locale';
+
+export type ActivityData = {
+  id: number;
+  userInitials: string;
+  userName: string;
+  content: string;
+  timeAgo: string;
+  userColor: string;
+};
+
+export async function getRecentActivity(limit: number = 3): Promise<ActivityData[]> {
+  const activities = await prisma.activity.findMany({
+    include: {
+      user: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+    take: limit,
+  });
+
+  // Générer des couleurs cohérentes basées sur le type d'activité
+  const colorMap = {
+    TASK_COMPLETED: 'primary',
+    TASK_STARTED: 'accent',
+    PROJECT_CREATED: 'success',
+    TASK_CREATED: 'warning',
+    PROJECT_UPDATED: 'secondary',
+  };
+
+  return activities.map(activity => {
+    const userInitials = activity.user.fullName
+      .split(' ')
+      .map(part => part.charAt(0))
+      .join('')
+      .toUpperCase();
+
+    // Déterminer la couleur basée sur le type d'activité
+    const activityType = activity.type as keyof typeof colorMap;
+    const userColor = colorMap[activityType] || 'primary';
+
+    return {
+      id: activity.id,
+      userInitials,
+      userName: activity.user.fullName,
+      content: activity.content,
+      timeAgo: formatDistanceToNow(activity.createdAt, { addSuffix: true, locale: fr }),
+      userColor,
+    };
+  });
+} 

--- a/src/action/activity/getRecentActivity.ts
+++ b/src/action/activity/getRecentActivity.ts
@@ -58,4 +58,4 @@ export async function getRecentActivity(limit: number = 3): Promise<ActivityData
     console.error('Erreur lors de la récupération des activités:', error);
     return [];
   }
-} 
+}

--- a/src/action/activity/getRecentActivity.ts
+++ b/src/action/activity/getRecentActivity.ts
@@ -14,43 +14,48 @@ export type ActivityData = {
 };
 
 export async function getRecentActivity(limit: number = 3): Promise<ActivityData[]> {
-  const activities = await prisma.activity.findMany({
-    include: {
-      user: true,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: limit,
-  });
+  try {
+    const activities = await prisma.activity.findMany({
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: limit,
+    });
 
-  // Générer des couleurs cohérentes basées sur le type d'activité
-  const colorMap = {
-    TASK_COMPLETED: 'primary',
-    TASK_STARTED: 'accent',
-    PROJECT_CREATED: 'success',
-    TASK_CREATED: 'warning',
-    PROJECT_UPDATED: 'secondary',
-  };
-
-  return activities.map(activity => {
-    const userInitials = activity.user.fullName
-      .split(' ')
-      .map(part => part.charAt(0))
-      .join('')
-      .toUpperCase();
-
-    // Déterminer la couleur basée sur le type d'activité
-    const activityType = activity.type as keyof typeof colorMap;
-    const userColor = colorMap[activityType] || 'primary';
-
-    return {
-      id: activity.id,
-      userInitials,
-      userName: activity.user.fullName,
-      content: activity.content,
-      timeAgo: formatDistanceToNow(activity.createdAt, { addSuffix: true, locale: fr }),
-      userColor,
+    // Générer des couleurs cohérentes basées sur le type d'activité
+    const colorMap = {
+      TASK_COMPLETED: 'primary',
+      TASK_STARTED: 'accent',
+      PROJECT_CREATED: 'success',
+      TASK_CREATED: 'warning',
+      PROJECT_UPDATED: 'secondary',
     };
-  });
+
+    return activities.map(activity => {
+      const userInitials = activity.user.fullName
+        .split(' ')
+        .map(part => part.charAt(0))
+        .join('')
+        .toUpperCase();
+
+      // Déterminer la couleur basée sur le type d'activité
+      const activityType = activity.type as keyof typeof colorMap;
+      const userColor = colorMap[activityType] || 'primary';
+
+      return {
+        id: activity.id,
+        userInitials,
+        userName: activity.user.fullName,
+        content: activity.content,
+        timeAgo: formatDistanceToNow(activity.createdAt, { addSuffix: true, locale: fr }),
+        userColor,
+      };
+    });
+  } catch (error) {
+    console.error('Erreur lors de la récupération des activités:', error);
+    return [];
+  }
 } 

--- a/src/action/projects/__tests__/createProject.test.ts
+++ b/src/action/projects/__tests__/createProject.test.ts
@@ -9,6 +9,9 @@ jest.mock('@/lib/prisma', () => ({
     project: {
       create: jest.fn(),
     },
+    activity: {
+      create: jest.fn(),
+    },
   },
 }));
 

--- a/src/action/projects/createProject.ts
+++ b/src/action/projects/createProject.ts
@@ -4,6 +4,7 @@
 import { prisma } from '@/lib/prisma';
 import { requireAuth } from '@/lib/auth';
 import { revalidatePath } from 'next/cache';
+import { ActivityType } from '@prisma/client';
 
 type CreateProjectInput = {
   name: string;
@@ -51,6 +52,17 @@ export async function createProject(input: CreateProjectInput) {
         startDate,
         endDate,
         ownerId,
+      },
+    });
+
+    // Create activity
+    await prisma.activity.create({
+      data: {
+        userId: userId,
+        type: ActivityType.PROJECT_CREATED,
+        content: `Création du projet ${input.name}`,
+        entityId: project.id,
+        entityType: 'project',
       },
     });
 

--- a/src/action/tasks/changeTaskStatus.ts
+++ b/src/action/tasks/changeTaskStatus.ts
@@ -1,10 +1,17 @@
 'use server';
 
+import { requireAuth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { TaskStatus } from '@prisma/client';
+import { ActivityType, TaskStatus } from '@prisma/client';
 
 export default async function changeTaskStatus(taskId: string | number, status: string) {
   try {
+    const userId = await requireAuth();
+
+    if (!userId) {
+      return null;
+    }
+
     // Convert taskId from string to number
     const taskIdNumber = typeof taskId === 'string' ? parseInt(taskId, 10) : taskId;
 
@@ -20,6 +27,29 @@ export default async function changeTaskStatus(taskId: string | number, status: 
         status: taskStatus,
       },
     });
+
+    // Create activity
+    if (taskStatus === TaskStatus.COMPLETED) {
+      await prisma.activity.create({
+        data: {
+          userId: userId,
+          type: ActivityType.TASK_COMPLETED,
+          content: `Tâche ${updatedTask.title} terminée`,
+          entityId: updatedTask.id,
+          entityType: 'task',
+        },
+      });
+    } else if (taskStatus === TaskStatus.IN_PROGRESS) {
+      await prisma.activity.create({
+        data: {
+          userId: userId,
+          type: ActivityType.TASK_STARTED,
+          content: `Tâche ${updatedTask.title} démarrée`,
+          entityId: updatedTask.id,
+          entityType: 'task',
+        },
+      });
+    }
 
     return { success: true, task: updatedTask };
   } catch (error) {

--- a/src/app/dashboard/HomepageClient.tsx
+++ b/src/app/dashboard/HomepageClient.tsx
@@ -21,6 +21,7 @@ import Link from 'next/link';
 import { itemVariants } from '@/utils/ItemVariants';
 import type { CalendarData } from '@/app/dashboard/CalendarEvents';
 import { useTour } from '@/hook/useTour';
+import ActivityFeed from '@/components/dashboard/ActivityFeed';
 
 // Animation variants
 const containerVariants = {
@@ -193,56 +194,7 @@ export default function HomepageClient({ dashboardData, calendarData }: Dashboar
           <MiniCalendar calendarData={calendarData} id="dashboard-calendar" />
 
           {/* Activity Feed */}
-          <motion.div
-            variants={itemVariants}
-            className="bg-[var(--background-secondary)] border border-[var(--border)] rounded-xl p-5"
-            id="dashboard-activity"
-          >
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-[var(--foreground)]">Activité récente</h2>
-            </div>
-
-            <div className="space-y-4">
-              <div className="flex gap-3">
-                <div className="h-8 w-8 rounded-full bg-[var(--primary)] flex items-center justify-center text-[var(--primary-foreground)] text-sm font-medium">
-                  JD
-                </div>
-                <div>
-                  <p className="text-sm text-[var(--foreground)]">
-                    <span className="font-medium">John Doe</span> a terminé la tâche{' '}
-                    <span className="font-medium">Create API endpoints</span>
-                  </p>
-                  <p className="text-xs text-[var(--foreground-tertiary)] mt-1">Il y a 2 heures</p>
-                </div>
-              </div>
-
-              <div className="flex gap-3">
-                <div className="h-8 w-8 rounded-full bg-[var(--accent)] flex items-center justify-center text-[var(--accent-foreground)] text-sm font-medium">
-                  JS
-                </div>
-                <div>
-                  <p className="text-sm text-[var(--foreground)]">
-                    <span className="font-medium">Jane Smith</span> a commencé la tâche{' '}
-                    <span className="font-medium">Implement responsive layout</span>
-                  </p>
-                  <p className="text-xs text-[var(--foreground-tertiary)] mt-1">Il y a 5 heures</p>
-                </div>
-              </div>
-
-              <div className="flex gap-3">
-                <div className="h-8 w-8 rounded-full bg-[var(--success)] flex items-center justify-center text-[var(--success-foreground)] text-sm font-medium">
-                  AU
-                </div>
-                <div>
-                  <p className="text-sm text-[var(--foreground)]">
-                    <span className="font-medium">Admin User</span> a créé un nouveau projet{' '}
-                    <span className="font-medium">Mobile App Development</span>
-                  </p>
-                  <p className="text-xs text-[var(--foreground-tertiary)] mt-1">Hier</p>
-                </div>
-              </div>
-            </div>
-          </motion.div>
+          <ActivityFeed />
         </div>
       </div>
     </motion.div>

--- a/src/components/dashboard/ActivityFeed.tsx
+++ b/src/components/dashboard/ActivityFeed.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { itemVariants } from '@/utils/ItemVariants';
+import { useEffect, useState } from 'react';
+import { getRecentActivity, ActivityData } from '@/action/activity/getRecentActivity';
+
+export default function ActivityFeed() {
+  const [activities, setActivities] = useState<ActivityData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchActivities() {
+      try {
+        const data = await getRecentActivity(3);
+        setActivities(data);
+      } catch (error) {
+        console.error('Erreur lors de la récupération des activités:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchActivities();
+  }, []);
+
+  return (
+    <motion.section
+      variants={itemVariants}
+      className="bg-[var(--background-secondary)] border border-[var(--border)] rounded-xl p-5"
+      id="dashboard-activity"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">Activité récente</h2>
+      </div>
+
+      <div className="space-y-4">
+        {loading ? (
+          <div className="flex justify-center py-4">
+            <div className="animate-pulse h-4 w-3/4 bg-[var(--border)] rounded"></div>
+          </div>
+        ) : activities.length === 0 ? (
+          <p className="text-sm text-[var(--foreground-tertiary)] text-center py-2">
+            Aucune activité récente
+          </p>
+        ) : (
+          activities.map((activity) => (
+            <div key={activity.id} className="flex gap-3">
+              <div className={`h-8 w-8 rounded-full bg-[var(--${activity.userColor})] flex items-center justify-center text-[var(--${activity.userColor}-foreground)] text-sm font-medium`}>
+                {activity.userInitials}
+              </div>
+              <div>
+                <p className="text-sm text-[var(--foreground)]">
+                  <span className="font-medium">{activity.userName}</span> {activity.content}
+                </p>
+                <p className="text-xs text-[var(--foreground-tertiary)] mt-1">{activity.timeAgo}</p>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </motion.section>
+  );
+}

--- a/src/components/dashboard/ActivityFeed.tsx
+++ b/src/components/dashboard/ActivityFeed.tsx
@@ -44,9 +44,11 @@ export default function ActivityFeed() {
             Aucune activité récente
           </p>
         ) : (
-          activities.map((activity) => (
+          activities.map(activity => (
             <div key={activity.id} className="flex gap-3">
-              <div className={`h-8 w-8 rounded-full bg-[var(--${activity.userColor})] flex items-center justify-center text-[var(--${activity.userColor}-foreground)] text-sm font-medium`}>
+              <div
+                className={`h-8 w-8 rounded-full bg-[var(--${activity.userColor})] flex items-center justify-center text-[var(--${activity.userColor}-foreground)] text-sm font-medium`}
+              >
                 {activity.userInitials}
               </div>
               <div>


### PR DESCRIPTION
This pull request introduces a new activity tracking feature, including database schema updates, backend logic, and frontend integration. The changes enable tracking and displaying recent user activities in the dashboard.

### Database Changes:
* Added a new `Activity` model and `ActivityType` enum to the database schema, along with a corresponding migration to create the `activities` table and define relationships with the `users` table. (`prisma/migrations/20250514165037_add_activity_model/migration.sql`, `prisma/schema.prisma`) [[1]](diffhunk://#diff-3a4076523212d03cbb4a3a0c93f599e08c5a0e3ac511f3d26489485c3a96d4c1R1-R18) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR61) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR127-R148)

### Backend Logic:
* Implemented the `getRecentActivity` function to fetch recent activity data from the database, process it, and return it in a format suitable for the frontend. (`src/action/activity/getRecentActivity.ts`)

### Frontend Integration:
* Replaced the static activity feed in the dashboard with a new `ActivityFeed` component that dynamically fetches and displays recent activities. (`src/app/dashboard/HomepageClient.tsx`, `src/components/dashboard/ActivityFeed.tsx`) [[1]](diffhunk://#diff-11593989d8984eba0477f9fa904474e2e3557cc0cdf4d22b177d9fd9b02de47aR24) [[2]](diffhunk://#diff-11593989d8984eba0477f9fa904474e2e3557cc0cdf4d22b177d9fd9b02de47aL196-R197) [[3]](diffhunk://#diff-fb2d26f07ecc3dc237a8149f557b7bec3c6cb7821d05d27bbf2d0ffba6b91743R1-R64)