### PR TITLE
🩹 Fix patchnote display

### DIFF
--- a/docs/patchnotes/patchnote-draft.json
+++ b/docs/patchnotes/patchnote-draft.json
@@ -100,7 +100,7 @@
         "name": "patchnotes",
         "description": "Ajout de la documentation de la feature des `patchnotes`",
         "pr_number": "50"
-      } 
+      }
     ]
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -10,6 +10,8 @@ async function main() {
     await prisma.task.deleteMany();
     await prisma.project.deleteMany();
     await prisma.userSettings.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.patchNoteView.deleteMany();
     await prisma.user.deleteMany();
   }
 

--- a/src/action/patchnote/__tests__/patchnote.test.ts
+++ b/src/action/patchnote/__tests__/patchnote.test.ts
@@ -186,7 +186,6 @@ describe('Patch Note Functions', () => {
           patchNoteId: 1,
         },
       });
-      expect(revalidatePath).toHaveBeenCalledWith('/dashboard');
     });
 
     it('should handle errors and return false', async () => {

--- a/src/action/patchnote/__tests__/patchnote.test.ts
+++ b/src/action/patchnote/__tests__/patchnote.test.ts
@@ -289,21 +289,21 @@ describe('Patch Note Functions', () => {
     it('should return false if authentication fails', async () => {
       // Mock auth failure
       (requireAuth as jest.Mock).mockResolvedValue(null);
-      
+
       const result = await markAllPatchnotesAsRead();
-      
+
       expect(result).toBe(false);
       expect(prisma.patchNote.findMany).not.toHaveBeenCalled();
     });
-    
+
     it('should return true if no unread patchnotes are found', async () => {
       // Mock successful auth
       (requireAuth as jest.Mock).mockResolvedValue(1);
       // Mock empty result
       (prisma.patchNote.findMany as jest.Mock).mockResolvedValue([]);
-      
+
       const result = await markAllPatchnotesAsRead();
-      
+
       expect(result).toBe(true);
       expect(prisma.patchNote.findMany).toHaveBeenCalledWith({
         where: {
@@ -320,20 +320,17 @@ describe('Patch Note Functions', () => {
       });
       expect(prisma.patchNoteView.createMany).not.toHaveBeenCalled();
     });
-    
+
     it('should mark all unread patchnotes as read', async () => {
       // Mock successful auth
       (requireAuth as jest.Mock).mockResolvedValue(1);
       // Mock unread patchnotes
-      (prisma.patchNote.findMany as jest.Mock).mockResolvedValue([
-        { id: 1 },
-        { id: 2 },
-      ]);
+      (prisma.patchNote.findMany as jest.Mock).mockResolvedValue([{ id: 1 }, { id: 2 }]);
       // Mock successful creation
       (prisma.patchNoteView.createMany as jest.Mock).mockResolvedValue({ count: 2 });
-      
+
       const result = await markAllPatchnotesAsRead();
-      
+
       expect(result).toBe(true);
       expect(prisma.patchNoteView.createMany).toHaveBeenCalledWith({
         data: [
@@ -343,15 +340,15 @@ describe('Patch Note Functions', () => {
       });
       expect(revalidatePath).toHaveBeenCalledWith('/dashboard');
     });
-    
+
     it('should handle errors and return false', async () => {
       // Mock successful auth
       (requireAuth as jest.Mock).mockResolvedValue(1);
       // Mock error
       (prisma.patchNote.findMany as jest.Mock).mockRejectedValue(new Error('Database error'));
-      
+
       const result = await markAllPatchnotesAsRead();
-      
+
       expect(result).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
         'Error marking all patchnotes as read:',
@@ -359,26 +356,26 @@ describe('Patch Note Functions', () => {
       );
     });
   });
-  
+
   describe('markAllPatchnotesAsUnread', () => {
     it('should return false if authentication fails', async () => {
       // Mock auth failure
       (requireAuth as jest.Mock).mockResolvedValue(null);
-      
+
       const result = await markAllPatchnotesAsUnread();
-      
+
       expect(result).toBe(false);
       expect(prisma.patchNoteView.deleteMany).not.toHaveBeenCalled();
     });
-    
+
     it('should delete all view records for the user', async () => {
       // Mock successful auth
       (requireAuth as jest.Mock).mockResolvedValue(1);
       // Mock successful deletion
       (prisma.patchNoteView.deleteMany as jest.Mock).mockResolvedValue({ count: 5 });
-      
+
       const result = await markAllPatchnotesAsUnread();
-      
+
       expect(result).toBe(true);
       expect(prisma.patchNoteView.deleteMany).toHaveBeenCalledWith({
         where: {
@@ -387,15 +384,15 @@ describe('Patch Note Functions', () => {
       });
       expect(revalidatePath).toHaveBeenCalledWith('/dashboard');
     });
-    
+
     it('should handle errors and return false', async () => {
       // Mock successful auth
       (requireAuth as jest.Mock).mockResolvedValue(1);
       // Mock error
       (prisma.patchNoteView.deleteMany as jest.Mock).mockRejectedValue(new Error('Database error'));
-      
+
       const result = await markAllPatchnotesAsUnread();
-      
+
       expect(result).toBe(false);
       expect(console.error).toHaveBeenCalledWith(
         'Error marking all patchnotes as unread:',

--- a/src/action/patchnote/__tests__/patchnote.test.ts
+++ b/src/action/patchnote/__tests__/patchnote.test.ts
@@ -2,14 +2,19 @@ import {
   checkUnreadPatchnotes,
   markPatchnoteAsRead,
   getAllPatchnotes,
+  markAllPatchnotesAsRead,
+  markAllPatchnotesAsUnread,
 } from '@/action/patchnote/patchnote';
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
+import { requireAuth } from '@/lib/auth';
 
 // Mocks
 jest.mock('@/lib/prisma', () => {
   const mockFindMany = jest.fn();
   const mockCreate = jest.fn();
+  const mockCreateMany = jest.fn();
+  const mockDeleteMany = jest.fn();
 
   return {
     prisma: {
@@ -18,6 +23,8 @@ jest.mock('@/lib/prisma', () => {
       },
       patchNoteView: {
         create: mockCreate,
+        createMany: mockCreateMany,
+        deleteMany: mockDeleteMany,
       },
     },
   };
@@ -25,6 +32,10 @@ jest.mock('@/lib/prisma', () => {
 
 jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
+}));
+
+jest.mock('@/lib/auth', () => ({
+  requireAuth: jest.fn(),
 }));
 
 describe('Patch Note Functions', () => {
@@ -271,6 +282,125 @@ describe('Patch Note Functions', () => {
 
       expect(result).toEqual([]);
       expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('markAllPatchnotesAsRead', () => {
+    it('should return false if authentication fails', async () => {
+      // Mock auth failure
+      (requireAuth as jest.Mock).mockResolvedValue(null);
+      
+      const result = await markAllPatchnotesAsRead();
+      
+      expect(result).toBe(false);
+      expect(prisma.patchNote.findMany).not.toHaveBeenCalled();
+    });
+    
+    it('should return true if no unread patchnotes are found', async () => {
+      // Mock successful auth
+      (requireAuth as jest.Mock).mockResolvedValue(1);
+      // Mock empty result
+      (prisma.patchNote.findMany as jest.Mock).mockResolvedValue([]);
+      
+      const result = await markAllPatchnotesAsRead();
+      
+      expect(result).toBe(true);
+      expect(prisma.patchNote.findMany).toHaveBeenCalledWith({
+        where: {
+          published: true,
+          userViews: {
+            none: {
+              userId: 1,
+            },
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(prisma.patchNoteView.createMany).not.toHaveBeenCalled();
+    });
+    
+    it('should mark all unread patchnotes as read', async () => {
+      // Mock successful auth
+      (requireAuth as jest.Mock).mockResolvedValue(1);
+      // Mock unread patchnotes
+      (prisma.patchNote.findMany as jest.Mock).mockResolvedValue([
+        { id: 1 },
+        { id: 2 },
+      ]);
+      // Mock successful creation
+      (prisma.patchNoteView.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+      
+      const result = await markAllPatchnotesAsRead();
+      
+      expect(result).toBe(true);
+      expect(prisma.patchNoteView.createMany).toHaveBeenCalledWith({
+        data: [
+          { userId: 1, patchNoteId: 1 },
+          { userId: 1, patchNoteId: 2 },
+        ],
+      });
+      expect(revalidatePath).toHaveBeenCalledWith('/dashboard');
+    });
+    
+    it('should handle errors and return false', async () => {
+      // Mock successful auth
+      (requireAuth as jest.Mock).mockResolvedValue(1);
+      // Mock error
+      (prisma.patchNote.findMany as jest.Mock).mockRejectedValue(new Error('Database error'));
+      
+      const result = await markAllPatchnotesAsRead();
+      
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        'Error marking all patchnotes as read:',
+        expect.any(Error)
+      );
+    });
+  });
+  
+  describe('markAllPatchnotesAsUnread', () => {
+    it('should return false if authentication fails', async () => {
+      // Mock auth failure
+      (requireAuth as jest.Mock).mockResolvedValue(null);
+      
+      const result = await markAllPatchnotesAsUnread();
+      
+      expect(result).toBe(false);
+      expect(prisma.patchNoteView.deleteMany).not.toHaveBeenCalled();
+    });
+    
+    it('should delete all view records for the user', async () => {
+      // Mock successful auth
+      (requireAuth as jest.Mock).mockResolvedValue(1);
+      // Mock successful deletion
+      (prisma.patchNoteView.deleteMany as jest.Mock).mockResolvedValue({ count: 5 });
+      
+      const result = await markAllPatchnotesAsUnread();
+      
+      expect(result).toBe(true);
+      expect(prisma.patchNoteView.deleteMany).toHaveBeenCalledWith({
+        where: {
+          userId: 1,
+        },
+      });
+      expect(revalidatePath).toHaveBeenCalledWith('/dashboard');
+    });
+    
+    it('should handle errors and return false', async () => {
+      // Mock successful auth
+      (requireAuth as jest.Mock).mockResolvedValue(1);
+      // Mock error
+      (prisma.patchNoteView.deleteMany as jest.Mock).mockRejectedValue(new Error('Database error'));
+      
+      const result = await markAllPatchnotesAsUnread();
+      
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        'Error marking all patchnotes as unread:',
+        expect.any(Error)
+      );
     });
   });
 });

--- a/src/action/patchnote/patchnote.ts
+++ b/src/action/patchnote/patchnote.ts
@@ -78,9 +78,6 @@ export async function markPatchnoteAsRead(patchNoteId: number, userId: number): 
       },
     });
 
-    // Revalidate the dashboard page to update any UI that depends on patchnote status
-    revalidatePath('/dashboard');
-
     return true;
   } catch (error) {
     console.error('Error marking patchnote as read:', error);

--- a/src/app/dashboard/patchnotes/[id]/page.tsx
+++ b/src/app/dashboard/patchnotes/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import PatchnoteDetail from './PatchnoteDetails';
 import PatchnoteDetailSkeleton from './PatchnoteDetailSkeleton';
 import getPatchnote from '@/action/patchnote/getPatchnote';
+import { markPatchnoteAsRead } from '@/action/patchnote/patchnote';
+import { requireAuth } from '@/lib/auth';
 
 export default async function PatchnotePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -21,10 +23,13 @@ export default async function PatchnotePage({ params }: { params: Promise<{ id: 
 
 async function PatchnotePageContent({ id }: { id: number }) {
   const patchnote = await getPatchnote(id);
+  const userId = await requireAuth();
 
-  if (!patchnote) {
+  if (!patchnote || !userId) {
     return notFound();
   }
+
+  markPatchnoteAsRead(id, userId);
 
   return <PatchnoteDetail patchnote={patchnote} />;
 }

--- a/src/components/patchnote/PatchnoteModal.tsx
+++ b/src/components/patchnote/PatchnoteModal.tsx
@@ -138,13 +138,13 @@ export default function PatchNoteModal({
             <div className="sticky top-0 z-20 flex items-center justify-between border-b border-[var(--border)] bg-[var(--background-secondary)]/90 p-4 backdrop-blur-sm">
               <div className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--primary-muted)] text-[var(--primary)] border border-[var(--primary)]/30">
-                  <span className="text-2xl">{patchNote.emoji || '✨'}</span>
+                  <span className="text-2xl">{patchNote?.emoji || '✨'}</span>
                 </div>
                 <div>
-                  <h3 className="text-xl font-bold text-[var(--foreground)]">{patchNote.title}</h3>
+                  <h3 className="text-xl font-bold text-[var(--foreground)]">{patchNote?.title}</h3>
                   <div className="flex items-center gap-2 mt-1">
                     <p className="text-sm text-[var(--foreground-tertiary)]">
-                      {new Date(patchNote.releaseDate).toLocaleDateString('fr-FR', {
+                      {new Date(patchNote?.releaseDate || '').toLocaleDateString('fr-FR', {
                         day: 'numeric',
                         month: 'long',
                         year: 'numeric',

--- a/src/components/patchnote/PatchnoteModalContainer.tsx
+++ b/src/components/patchnote/PatchnoteModalContainer.tsx
@@ -3,11 +3,12 @@
 import { useState, useEffect } from 'react';
 import PatchNoteModal from './PatchnoteModal';
 import { PatchNote } from '@prisma/client';
+import { useRouter } from 'next/navigation';
 
-interface PatchnoteModalContainerProps {
+type PatchnoteModalContainerProps = {
   patchnote: PatchNote[];
   markAsReadAction: (patchnoteId: number) => Promise<void>;
-}
+};
 
 export default function PatchnoteModalContainer({
   patchnote,
@@ -15,6 +16,7 @@ export default function PatchnoteModalContainer({
 }: PatchnoteModalContainerProps) {
   const [showModal, setShowModal] = useState(false);
   const [currentPatchnoteIndex, setCurrentPatchnoteIndex] = useState(0);
+  const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -31,6 +33,7 @@ export default function PatchnoteModalContainer({
       setCurrentPatchnoteIndex(currentPatchnoteIndex + 1);
     } else {
       setShowModal(false);
+      router.refresh();
     }
   };
 

--- a/src/components/patchnote/PatchnotesDropdown.tsx
+++ b/src/components/patchnote/PatchnotesDropdown.tsx
@@ -4,13 +4,13 @@ import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { PatchNote } from '@prisma/client';
-import { markPatchnoteAsRead } from '@/action/patchnote/patchnote';
+import { markAllPatchnotesAsRead, markPatchnoteAsRead } from '@/action/patchnote/patchnote';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 
-interface PatchnotesDropdownProps {
+type PatchnotesDropdownProps = {
   patchnotes: PatchNote[];
-}
+};
 
 export default function PatchnotesDropdown({ patchnotes }: PatchnotesDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -41,6 +41,11 @@ export default function PatchnotesDropdown({ patchnotes }: PatchnotesDropdownPro
     } catch (error) {
       console.error('Error marking patchnote as read:', error);
     }
+  };
+
+  const handleMarkAllPatchnotesAsRead = async () => {
+    await markAllPatchnotesAsRead();
+    setIsOpen(false);
   };
 
   const hasUnreadPatchnotes = patchnotes?.length > 0;
@@ -130,7 +135,7 @@ export default function PatchnotesDropdown({ patchnotes }: PatchnotesDropdownPro
               <div className="p-2 border-t border-[var(--border)]">
                 <button
                   className="w-full py-2 px-3 bg-[var(--primary)] hover:bg-[var(--primary-hover)] rounded-md text-sm font-medium text-[var(--primary-foreground)] transition-colors"
-                  onClick={() => setIsOpen(false)}
+                  onClick={handleMarkAllPatchnotesAsRead}
                 >
                   Marquer tout comme lu
                 </button>

--- a/src/components/patchnote/PatchnotesDropdown.tsx
+++ b/src/components/patchnote/PatchnotesDropdown.tsx
@@ -4,7 +4,10 @@ import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { PatchNote } from '@prisma/client';
-import { markAllPatchnotesAsRead, markPatchnoteAsRead } from '@/action/patchnote/patchnote';
+import {
+  markAllPatchnotesAsRead,
+  markPatchnoteAsRead,
+} from '@/action/patchnote/patchnote';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 

--- a/src/components/patchnote/PatchnotesDropdown.tsx
+++ b/src/components/patchnote/PatchnotesDropdown.tsx
@@ -4,10 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { PatchNote } from '@prisma/client';
-import {
-  markAllPatchnotesAsRead,
-  markPatchnoteAsRead,
-} from '@/action/patchnote/patchnote';
+import { markAllPatchnotesAsRead, markPatchnoteAsRead } from '@/action/patchnote/patchnote';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 


### PR DESCRIPTION
This pull request introduces new features and improvements related to patch note management, including marking all patch notes as read or unread, enhancing testing coverage, and improving UI behavior. The changes also include minor code refactoring for better readability and functionality.

### New Features and Enhancements:

* **Mark All Patch Notes as Read/Unread**:
  - Added `markAllPatchnotesAsRead` and `markAllPatchnotesAsUnread` functions to handle bulk updates to patch note statuses. These functions include authentication checks, database updates, and UI revalidation. (`src/action/patchnote/patchnote.ts`)
  - Integrated the new functions into the `PatchnotesDropdown` component, allowing users to mark all patch notes as read via a button in the dropdown menu. (`src/components/patchnote/PatchnotesDropdown.tsx`) [[1]](diffhunk://#diff-bfd859a3636598b1c75992c7f591d3185127f177c5d905982d5e362faa7bc589R49-R53) [[2]](diffhunk://#diff-bfd859a3636598b1c75992c7f591d3185127f177c5d905982d5e362faa7bc589L133-R141)

* **Improved Testing Coverage**:
  - Added tests for `markAllPatchnotesAsRead` and `markAllPatchnotesAsUnread` to ensure proper handling of authentication, database operations, and error cases. (`src/action/patchnote/__tests__/patchnote.test.ts`)

### Code Refactoring and Improvements:

* **Authentication Integration**:
  - Introduced `requireAuth` in multiple functions to ensure authenticated users perform actions like marking patch notes as read. (`src/action/patchnote/patchnote.ts`, `src/app/dashboard/patchnotes/[id]/page.tsx`) ([src/action/patchnote/patchnote.tsR6](diffhunk://#diff-0fa875c5f7dca5b1e9086d974e81669b161fe41df6c30c84f34810377413e329R6), [src/app/dashboard/patchnotes/[id]/page.tsxR26-R33](diffhunk://#diff-86372150fe8f219adcd53c97b19ecd61218e2632f45a13e9c5cb280bb909974eR26-R33))

* **UI Updates**:
  - Updated `PatchnoteModalContainer` to refresh the page after closing the modal to reflect changes in the UI. (`src/components/patchnote/PatchnoteModalContainer.tsx`)

* **Minor Fixes**:
  - Used optional chaining for safer access to `patchNote` properties in `PatchnoteModal`. (`src/components/patchnote/PatchnoteModal.tsx`)

### Database Seeding Adjustment:

* Updated the seeding script to clear `activity` and `patchNoteView` tables during initialization. (`prisma/seed.ts`)