### PR TITLE
💚 Fix CI patchnote

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,7 +8,7 @@ jobs:
   lint-format:
     name: ESLint & Prettier Check
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.pull_request.title, 'patchnote/')"
+    if: "!startsWith(github.event.pull_request.head.ref, 'patchnote/')"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/patchnote-check.yml
+++ b/.github/workflows/patchnote-check.yml
@@ -8,7 +8,7 @@ jobs:
   check-patches:
     name: Check Patchnote Changes
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.title, 'patchnote/')
+    if: startsWith(github.event.pull_request.head.ref, 'patchnote/')
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Run Jest Tests
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.pull_request.title, 'patchnote/')"
+    if: "!startsWith(github.event.pull_request.head.ref, 'patchnote/')"
 
     env:
       NODE_ENV: test

--- a/docs/patchnotes/patchnote-draft.json
+++ b/docs/patchnotes/patchnote-draft.json
@@ -96,7 +96,7 @@
       },
       {
         "name": "patchnote-workflows",
-        "description": "👷 Fix patchnote CI",
+        "description": "Ajout des workflows pour la validation des pull requests pour les branches de patchnotes",
         "pr_number": "90"
       }
     ],

--- a/docs/patchnotes/patchnote-draft.json
+++ b/docs/patchnotes/patchnote-draft.json
@@ -93,6 +93,11 @@
         "name": "eslint",
         "description": "Ajout d'un workflow pour la validation du code avec ESLint et Prettier",
         "pr_number": "78"
+      },
+      {
+        "name": "patchnote-workflows",
+        "description": "👷 Fix patchnote CI",
+        "pr_number": "90"
       }
     ],
     "other-changes": [


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve how patchnote-related branches are handled and adds documentation for these changes in the patchnotes draft file. The key updates include switching from checking the pull request title to checking the branch name for workflows and documenting the new workflows.

### Workflow updates:
* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L11-R11): Updated the `lint-format` job to check the pull request branch name (`head.ref`) instead of the title when determining if the workflow should run.
* [`.github/workflows/patchnote-check.yml`](diffhunk://#diff-4057287a9e53f87d955348fc92084ae6a3b393a9dbfe7daaa2dbc13de0c891b3L11-R11): Updated the `check-patches` job to use the branch name (`head.ref`) instead of the title for identifying patchnote-related pull requests.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL14-R14): Updated the `test` job to use the branch name (`head.ref`) instead of the title for deciding whether to run tests.

### Documentation updates:
* [`docs/patchnotes/patchnote-draft.json`](diffhunk://#diff-5b2b71a4d391cc5e12b08dec79d6c4d356dfa4305f95b7d6369984cd826f635dR96-R100): Added an entry documenting the addition of workflows for validating pull requests related to patchnote branches.