### PR TITLE
:ambulance: Fix error handling in task status update for KanbanPage

### DIFF
--- a/src/app/dashboard/projects/[id]/kanban/KanbanClient.tsx
+++ b/src/app/dashboard/projects/[id]/kanban/KanbanClient.tsx
@@ -128,8 +128,8 @@ export default function KanbanPage({ project }: KanbanProps) {
     try {
       const result = await changeTaskStatus(draggingTask.id.toString(), destinationStatus);
 
-      if (!result.success) {
-        console.error('Failed to update task status:', result.error);
+      if (!result || !result.success) {
+        console.error('Failed to update task status:', result?.error);
       }
     } catch (error) {
       console.error('Error updating task status:', error);


### PR DESCRIPTION
This pull request includes a small change to the `KanbanClient.tsx` file. The change improves error handling when updating a task's status by adding a null check for the `result` object.

* `src/app/dashboard/projects/[id]/kanban/KanbanClient.tsx`: Updated the condition to check for both `result` being null or undefined and `result.success` being false, preventing potential runtime errors. ([src/app/dashboard/projects/[id]/kanban/KanbanClient.tsxL131-R132](diffhunk://#diff-01d3f00e3b3ed0f084304ae4857fa79acfa030a58e67844b594d5d9262695a3cL131-R132))